### PR TITLE
Quote identifier names when --no-color is specified

### DIFF
--- a/spec/cli_spec.lua
+++ b/spec/cli_spec.lua
@@ -67,11 +67,11 @@ Total: ###5# warnings / ##0# errors in 2 files
 Checking spec/samples/good_code.lua               OK
 Checking spec/samples/bad_code.lua                Failure
 
-    spec/samples/bad_code.lua:3:16: unused variable helper
+    spec/samples/bad_code.lua:3:16: unused variable 'helper'
     spec/samples/bad_code.lua:3:23: unused variable length argument
-    spec/samples/bad_code.lua:7:10: setting non-standard global variable embrace
-    spec/samples/bad_code.lua:8:10: variable opt was previously defined as an argument on line 7
-    spec/samples/bad_code.lua:9:11: accessing undefined variable hepler
+    spec/samples/bad_code.lua:7:10: setting non-standard global variable 'embrace'
+    spec/samples/bad_code.lua:8:10: variable 'opt' was previously defined as an argument on line 7
+    spec/samples/bad_code.lua:9:11: accessing undefined variable 'hepler'
 
 Total: 5 warnings / 0 errors in 2 files
 ]], get_output ("spec/samples/good_code.lua spec/samples/bad_code.lua --no-color", true))

--- a/spec/format_spec.lua
+++ b/spec/format_spec.lua
@@ -157,11 +157,11 @@ Total: 2 warnings / 1 error in 4 files]], remove_color(format({
    it("does not color output if options.color == false", function()
       assert.equal([[Checking stdin                                    Failure
 
-    stdin:2:7: unused global variable foo
+    stdin:2:7: unused global variable 'foo'
 
 Checking foo.lua                                  Failure
 
-    foo.lua:2:7: unused global variable foo
+    foo.lua:2:7: unused global variable 'foo'
 
 Checking bar.lua                                  OK
 Checking baz.lua                                  Syntax error


### PR DESCRIPTION
The output should be `unused variable 'helper'`  instead of `unused variable helper` when `--no-color` is specified. This makes the output unambiguous and more readable, and has the big advantage of making the variable name easier to parse (important for IDEs and other tools that call luacheck).

The code in `format.lua` may need refactoring.
