### PR TITLE
Added luacheck.bat file for Windows

### DIFF
--- a/bin/luacheck.bat
+++ b/bin/luacheck.bat
@@ -1,0 +1,2 @@
+@echo off
+lua.exe %~dp0\luacheck.lua %*


### PR DESCRIPTION
Allows you to run luacheck without preceding it with `lua.exe`.

Rockspec should be modified so that this file is copied into the path.