### PR TITLE
fix spelling error in docs. Thanks lintian for caring

### DIFF
--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -128,7 +128,7 @@ Pattern Matching warnings
 4.2/.*_ Shadowing declarations of arguments with ``_`` suffix or redefining them.
 ======= =========================================================================
 
-Unless already anchored, patterns matching variable names are anchored at both sides and patterns matching warning codes are anchored at their beginnings. This allows to filter warnings by category (e.g. ``--only 1`` focuses ``luacheck`` on global-related warnings).
+Unless already anchored, patterns matching variable names are anchored at both sides and patterns matching warning codes are anchored at their beginnings. This allows one to filter warnings by category (e.g. ``--only 1`` focuses ``luacheck`` on global-related warnings).
 
 Formatters
 ----------

--- a/docsrc/config.rst
+++ b/docsrc/config.rst
@@ -50,7 +50,7 @@ An example of a config which makes ``luacheck`` ensure that only globals from th
 Per-prefix overrides
 --------------------
 
-The environment in which ``luacheck`` loads the config contains a special global ``files``. When checking a file ``<path>``, ``luacheck`` will override options from the main config with entries from ``files[<path_prefix>]``, applying entries for shorter prefixes first. This allows to override options for a specific file by setting ``files[<path>]``, and for all files in a directory by setting ``files[<dir>/]``. For example, the following config re-enables detection of unused arguments only for files in ``src/dir``, but not for ``src/dir/myfile.lua``:
+The environment in which ``luacheck`` loads the config contains a special global ``files``. When checking a file ``<path>``, ``luacheck`` will override options from the main config with entries from ``files[<path_prefix>]``, applying entries for shorter prefixes first. This allows one to override options for a specific file by setting ``files[<path>]``, and for all files in a directory by setting ``files[<dir>/]``. For example, the following config re-enables detection of unused arguments only for files in ``src/dir``, but not for ``src/dir/myfile.lua``:
 
 .. code-block:: lua
    :linenos:


### PR DESCRIPTION
lua-check: spelling-error-in-manpage usr/share/man/man1/luacheck.1.gz allows to allows one to
lua-check: spelling-error-in-manpage usr/share/man/man1/luacheck.1.gz allows to allows one to