### PR TITLE
Add ngx_lua standard globals

### DIFF
--- a/src/luacheck/main.lua
+++ b/src/luacheck/main.lua
@@ -64,6 +64,7 @@ together with used ones.]])
    lua53 - globals of Lua 5.3;
    lua53c - globals of Lua 5.3 with LUA_COMPAT_5_2;
    luajit - globals of LuaJIT 2.0;
+   ngx_lua - globals of Openresty lua-nginx-module with LuaJIT 2.0;
    min - intersection of globals of Lua 5.1, Lua 5.2,
       Lua 5.3 and LuaJIT 2.0;
    max - union of globals of Lua 5.1, Lua 5.2, Lua 5.3

--- a/src/luacheck/stds.lua
+++ b/src/luacheck/stds.lua
@@ -49,6 +49,13 @@ stds.luajit = {
    "pcall", "print", "rawequal", "rawget", "rawset", "require", "select", "setfenv",
    "setmetatable", "string", "table", "tonumber", "tostring", "type", "unpack", "xpcall"}
 
+stds.ngx_lua = {
+   _G = true, package = true, "_VERSION", "arg", "assert", "bit", "collectgarbage", "coroutine",
+   "debug", "dofile", "error", "gcinfo", "getfenv", "getmetatable", "io", "ipairs", "jit",
+   "load", "loadfile", "loadstring", "math", "module", "newproxy", "ndk", "ngx", "next", "os",
+   "pairs", "pcall", "print", "rawequal", "rawget", "rawset", "require", "select", "setfenv",
+   "setmetatable", "string", "table", "tonumber", "tostring", "type", "unpack", "xpcall"}
+
 local min = {_G = true, package = true}
 local std_sets = {}
 
@@ -57,7 +64,9 @@ for name, std in pairs(stds) do
 end
 
 for global in pairs(std_sets.lua51) do
-   if std_sets.lua52[global] and std_sets.lua53[global] and std_sets.luajit[global] then
+   if std_sets.lua52[global] and std_sets.lua53[global]
+      and std_sets.luajit[global] and std_sets.ngx_lua[global]
+   then
       table.insert(min, global)
    end
 end


### PR DESCRIPTION
This commit adds globals for the popular [lua-nginx-module](https://github.com/openresty/lua-nginx-module). The only two added in addition to the "luajit" set are ngx and ndk.