### PR TITLE
Rockspec: use HTTPS instead of the Git protocol

### DIFF
--- a/luacheck-scm-1.rockspec
+++ b/luacheck-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "luacheck"
 version = "scm-1"
 source = {
-   url = "git://github.com/mpeterv/luacheck.git"
+   url = "https://github.com/mpeterv/luacheck.git"
 }
 description = {
    summary = "A static analyzer and a linter for Lua",


### PR DESCRIPTION
The Git protocol (port 9418) is blocked by many firewalls. Use the HTTPS
protocol (port 443) instead.

---

Problem arised here: https://github.com/neovim/neovim/issues/3769