### PR TITLE
docsrc: fix typos thanks to lintian

### DIFF
--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -38,7 +38,7 @@ The output of ``luacheck`` consists of separate reports for each checked file an
 
    Total: 14 warnings / 1 error in 4 files
 
-``luacheck`` exits with 0 if no warnings or errors occured and with a positive number otherwise.
+``luacheck`` exits with 0 if no warnings or errors occurred and with a positive number otherwise.
 
 .. _cliopts:
 

--- a/docsrc/inline.rst
+++ b/docsrc/inline.rst
@@ -28,7 +28,7 @@ only               1+
 
 Options that take no arguments can be prefixed with ``no`` to invert their meaning. E.g. ``--luacheck: no unused args`` disables unused argument warnings.
 
-Part of the file affected by inline option dependes on where it is placed. If there is any code on the line with the option, only that line is affected; otherwise, everthing till the end of the current closure is. In particular, inline options at the top of the file affect all of it:
+Part of the file affected by inline option dependes on where it is placed. If there is any code on the line with the option, only that line is affected; otherwise, everything till the end of the current closure is. In particular, inline options at the top of the file affect all of it:
 
 .. code-block:: lua
    :linenos:

--- a/docsrc/module.rst
+++ b/docsrc/module.rst
@@ -20,7 +20,7 @@ Report format
 
 A final report is an array of file reports plus fields ``warnings``, ``errors`` and ``fatals`` containing total number of warnings, errors and fatal errors, correspondingly.
 
-A file report is an array of issues (warnings or errors). If a fatal error occured while checking a file, its report will have ``fatal`` field containing error type and ``msg`` field containing error message.
+A file report is an array of issues (warnings or errors). If a fatal error occurred while checking a file, its report will have ``fatal`` field containing error type and ``msg`` field containing error message.
 
 An issue is a table with field ``code`` indicating its type (see :doc:`warnings`), and fields ``line``, ``column`` and ``end_column`` pointing to the source of the warning. ``name`` field may contain name of related variable. Issues of some types can also have additional fields:
 


### PR DESCRIPTION
> I: lua-check: spelling-error-in-manpage usr/share/man/man1/luacheck.1.gz occured occurred
> I: lua-check: spelling-error-in-manpage usr/share/man/man1/luacheck.1.gz everthing everything
> I: lua-check: spelling-error-in-manpage usr/share/man/man1/luacheck.1.gz occured occurred