### PR TITLE
add stds.rockspec for rockspec files.

### DIFF
--- a/src/luacheck/stds.lua
+++ b/src/luacheck/stds.lua
@@ -56,6 +56,10 @@ stds.ngx_lua = {
    "pairs", "pcall", "print", "rawequal", "rawget", "rawset", "require", "select", "setfenv",
    "setmetatable", "string", "table", "tonumber", "tostring", "type", "unpack", "xpcall"}
 
+stds.rockspec = {
+  "rockspec_format", "package", "version", "description", "supported_platforms",
+  "dependencies", "external_dependencies", "source", "build"}
+
 local min = {_G = true, package = true}
 local std_sets = {}
 


### PR DESCRIPTION
We added pattern match for filenames in #52 , which supports `.rockspec` files.

I was initially setting `files['*.rockspec'].global = false`.
But it would better like:

```lua
files['*.rockspec'].globals = {
  'rockspec_format',
  'package',
  'version',
  'description',
  'supported_platforms',
  'dependencies',
  'external_dependencies',
  'source',
  'build',
}
```

This is good, but not good enough.

Shall we add this `rockspec` std? So that would be simple as:

```lua
files['*.rockspec'].std = 'rockspec'
```

Rockspec format: https://github.com/keplerproject/luarocks/wiki/Rockspec-format