### PR TITLE
ngx_lua: support ngx_lua custom coroutine's fun

### DIFF
--- a/src/luacheck/builtin_standards.lua
+++ b/src/luacheck/builtin_standards.lua
@@ -257,7 +257,8 @@ lua_defs.luajit = add_defs(make_min_def("luajit"), {
 lua_defs.ngx_lua = add_defs(lua_defs.luajit, {
    fields = {
       ngx = {other_fields = true, read_only = false},
-      ndk = {other_fields = true}
+      ndk = {other_fields = true},
+      coroutine = {other_fields = true}
    }
 })
 lua_defs.max = add_defs(lua_defs.lua51c, lua_defs.lua52c, lua_defs.lua53c, lua_defs.luajit)


### PR DESCRIPTION
Hello

@mpeterv 

Now the newest luacheck 0.19.0 redefines the ngx_lua standard and it will make the CI failed because of `accessing undefined field _yield of global coroutine` in [lua-resty-core](https://github.com/openresty/lua-resty-core)

OpenResty inject the custom API to coroutine table as the following:

```c
    lua_getglobal(L, "coroutine");

    /* set running to the old one */
    lua_getfield(L, -1, "running");
    lua_setfield(L, -3, "running");

    lua_getfield(L, -1, "create");
    lua_setfield(L, -3, "_create");

    lua_getfield(L, -1, "resume");
    lua_setfield(L, -3, "_resume");

    lua_getfield(L, -1, "yield");
    lua_setfield(L, -3, "_yield");

    lua_getfield(L, -1, "status");
    lua_setfield(L, -3, "_status");

    /* pop the old coroutine */
    lua_pop(L, 1);

    lua_pushcfunction(L, ngx_http_lua_coroutine_create);
    lua_setfield(L, -2, "__create");

    lua_pushcfunction(L, ngx_http_lua_coroutine_resume);
    lua_setfield(L, -2, "__resume");

    lua_pushcfunction(L, ngx_http_lua_coroutine_yield);
    lua_setfield(L, -2, "__yield");

    lua_pushcfunction(L, ngx_http_lua_coroutine_status);
    lua_setfield(L, -2, "__status");

    lua_setglobal(L, "coroutine");
```

So add the coroutine fields to pass the CI.