### PR TITLE
Add LÖVE standard

### DIFF
--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -73,14 +73,15 @@ Option                                  Meaning
                                         * ``lua51c`` - globals of Lua 5.1;
                                         * ``lua52`` - globals of Lua 5.2;
                                         * ``lua52c`` - globals of Lua 5.2 compiled with LUA_COMPAT_ALL;
-                                        * ``lua53`` - globals of Lua 5.3; 
-                                        * ``lua53c`` - globals of Lua 5.3 compiled with LUA_COMPAT_5_2; 
+                                        * ``lua53`` - globals of Lua 5.3;
+                                        * ``lua53c`` - globals of Lua 5.3 compiled with LUA_COMPAT_5_2;
                                         * ``luajit`` - globals of LuaJIT 2.0;
                                         * ``ngx_lua`` - globals of Openresty `lua-nginx-module <https://github.com/openresty/lua-nginx-module>`_ with LuaJIT 2.0;
                                         * ``min`` - intersection of globals of Lua 5.1, Lua 5.2, Lua 5.3 and LuaJIT 2.0;
                                         * ``max`` - union of globals of Lua 5.1, Lua 5.2, Lua 5.3 and LuaJIT 2.0;
                                         * ``_G``  (default) - same as ``lua51c``, ``lua52c``, ``lua53c``, or ``luajit`` depending on version of Lua used
                                           to run ``luacheck`` or same as ``max`` if couldn't detect the version;
+                                        * ``love`` - globals added by `LÖVE <https://love2d.org>`_ (love2d);
                                         * ``busted`` - globals added by Busted 2.0;
                                         * ``rockspec`` - globals allowed in rockspecs;
                                         * ``none`` - no standard globals.

--- a/install.lua
+++ b/install.lua
@@ -109,6 +109,7 @@ for _, filename in ipairs {
       "options.lua",
       "inline_options.lua",
       "builtin_standards.lua",
+      "love_standard.lua",
       "expand_rockspec.lua",
       "multithreading.lua",
       "cache.lua",

--- a/luacheck-scm-1.rockspec
+++ b/luacheck-scm-1.rockspec
@@ -32,6 +32,7 @@ build = {
       ["luacheck.options"] = "src/luacheck/options.lua",
       ["luacheck.inline_options"] = "src/luacheck/inline_options.lua",
       ["luacheck.builtin_standards"] = "src/luacheck/builtin_standards.lua",
+      ["luacheck.love_standard"] = "src/luacheck/love_standard.lua",
       ["luacheck.expand_rockspec"] = "src/luacheck/expand_rockspec.lua",
       ["luacheck.multithreading"] = "src/luacheck/multithreading.lua",
       ["luacheck.cache"] = "src/luacheck/cache.lua",

--- a/src/luacheck/builtin_standards.lua
+++ b/src/luacheck/builtin_standards.lua
@@ -290,6 +290,8 @@ builtin_standards.busted = {
    }
 }
 
+builtin_standards.love = require "luacheck.love_standard"
+
 builtin_standards.rockspec = {
    globals = {
       "rockspec_format", "package", "version", "description", "supported_platforms",

--- a/src/luacheck/love_standard.lua
+++ b/src/luacheck/love_standard.lua
@@ -1,0 +1,124 @@
+local empty, read_write = {}, { read_only = false }
+
+local function def_fields(...)
+   local fields = {}
+
+   for _, field in ipairs({...}) do
+      fields[field] = empty
+   end
+
+   return {fields = fields}
+end
+
+local love = {
+   fields = {
+      getVersion = empty,
+      conf = read_write,
+      directorydropped = read_write,
+      draw = read_write,
+      errhand = read_write,
+      filedropped = read_write,
+      focus = read_write,
+      gamepadaxis = read_write,
+      gamepadpressed = read_write,
+      gamepadreleased = read_write,
+      joystickadded = read_write,
+      joystickaxis = read_write,
+      joystickhat = read_write,
+      joystickpressed = read_write,
+      joystickreleased = read_write,
+      joystickremoved = read_write,
+      keypressed = read_write,
+      keyreleased = read_write,
+      load = read_write,
+      lowmemory = read_write,
+      mousefocus = read_write,
+      mousemoved = read_write,
+      mousepressed = read_write,
+      mousereleased = read_write,
+      quit = read_write,
+      resize = read_write,
+      run = read_write,
+      textedited = read_write,
+      textinput = read_write,
+      threaderror = read_write,
+      touchmoved = read_write,
+      touchpressed = read_write,
+      touchreleased = read_write,
+      update = read_write,
+      visible = read_write,
+      wheelmoved = read_write,
+
+      audio = def_fields("getDistanceModel","getDopplerScale","getSourceCount","getOrientation",
+         "getPosition","getVelocity","getVolume","newSource","pause","play","resume","rewind",
+         "setDistanceModel","setDopplerScale","setOrientation","setPosition","setVelocity",
+         "setVolume","stop"),
+
+      event = def_fields("clear","poll","pump","push","quit","wait"),
+
+      filesystem = def_fields("append","areSymlinksEnabled","createDirectory","exists",
+         "getAppdataDirectory","getDirectoryItems","getIdentity","getLastModified",
+         "getRealDirectory","getRequirePath","getSaveDirectory","getSize","getSource",
+         "getSourceBaseDirectory","getUserDirectory","getWorkingDirectory","init","isDirectory",
+         "isFile","isFused","isSymlink","lines","load","mount","newFile","newFileData","read",
+         "remove","setIdentity","setRequirePath","setSource","setSymlinksEnabled","unmount","write"),
+
+      graphics = def_fields("arc","circle","clear","discard","draw","ellipse","getBackgroundColor",
+         "getBlendMode","getCanvas","getCanvasFormats","getColor","getColorMask",
+         "getCompressedImageFormats","getDefaultFilter","getDimensions","getFont","getHeight",
+         "getLineJoin","getLineStyle","getLineWidth","getShader","getStats","getStencilTest",
+         "getSupported","getSystemLimits","getPointSize","getRendererInfo","getScissor","getWidth",
+         "intersectScissor","isGammaCorrect","isWireframe","line","newCanvas","newFont","newMesh",
+         "newImage","newImageFont","newParticleSystem","newShader","newText","newQuad",
+         "newScreenshot","newSpriteBatch","newVideo","origin","points","polygon","pop","present",
+         "print","printf","push","rectangle","reset","rotate","scale","setBackgroundColor",
+         "setBlendMode","setCanvas","setColor","setColorMask","setDefaultFilter","setFont",
+         "setLineJoin","setLineStyle","setLineWidth","setNewFont","setShader","setPointSize",
+         "setScissor","setStencilTest","setWireframe","shear","stencil","translate"),
+
+      image = def_fields("isCompressed","newCompressedData","newImageData"),
+
+      joystick = def_fields("getJoystickCount","getJoysticks","loadGamepadMappings",
+         "saveGamepadMappings","setGamepadMapping"),
+
+      keyboard = def_fields("getKeyFromScancode","getScancodeFromKey","hasKeyRepeat","hasTextInput",
+         "isDown","isScancodeDown","setKeyRepeat","setTextInput"),
+
+      math = def_fields("compress","decompress","gammaToLinear","getRandomSeed","getRandomState",
+         "isConvex","linearToGamma","newBezierCurve","newRandomGenerator","noise","random",
+         "randomNormal","setRandomSeed","setRandomState","triangulate"),
+
+      mouse = def_fields("getCursor","getPosition","getRelativeMode","getSystemCursor","getX",
+         "getY","hasCursor","isDown","isGrabbed","isVisible","newCursor","setCursor","setGrabbed",
+         "setPosition","setRelativeMode","setVisible","setX","setY"),
+
+      physics = def_fields("getDistance","getMeter","newBody","newChainShape","newCircleShape",
+         "newDistanceJoint","newEdgeShape","newFixture","newFrictionJoint","newGearJoint",
+         "newMotorJoint","newMouseJoint","newPolygonShape","newPrismaticJoint","newPulleyJoint",
+         "newRectangleShape","newRevoluteJoint","newRopeJoint","newWeldJoint","newWheelJoint",
+         "newWorld","setMeter"),
+
+      sound = def_fields("newDecoder","newSoundData"),
+
+      system = def_fields("getClipboardText","getOS","getPowerInfo","getProcessorCount","openURL",
+         "setClipboardText","vibrate"),
+
+      thread = def_fields("getChannel","newChannel","newThread"),
+
+      timer = def_fields("getAverageDelta","getDelta","getFPS","getTime","sleep","step"),
+
+      touch = def_fields("getPosition","getPressure","getTouches"),
+
+      video = def_fields("newVideoStream"),
+
+      window = def_fields("close","fromPixels","getDisplayName","getFullscreen",
+         "getFullscreenModes","getIcon","getMode","getPixelScale","getPosition","getTitle",
+         "hasFocus","hasMouseFocus","isDisplaySleepEnabled","isMaximized","isOpen","isVisible",
+         "maximize","minimize","requestAttention","setDisplaySleepEnabled","setFullscreen",
+         "setIcon","setMode","setPosition","setTitle","showMessageBox","toPixels")
+   }
+}
+
+return {
+   read_globals = { love = love }
+}

--- a/src/luacheck/main.lua
+++ b/src/luacheck/main.lua
@@ -76,6 +76,7 @@ together with used ones.]]):target("unused_secondaries"):action("store_false")
       depending on version of Lua used to run luacheck
       or same as max if couldn't detect the version.
       Currently %s;
+   love - globals added by LOVE (love2d);
    busted - globals added by Busted 2.0;
    rockspec - globals allowed in rockspecs;
    none - no standard globals.


### PR DESCRIPTION
Adds an standard for the LÖVE game framework, named `love`

This standard is provided as an additional standard similar to `busted`, and should be used with a Lua version like `luajit+love`. The recommended version is LuaJIT since that is the version bundled with LÖVE.

The standard was generated automatically with the [luacheck-love](https://github.com/Positive07/luacheck-love) script using the [love-api](https://github.com/love2d-community/love-api) tables.