### PR TITLE
Clarification on purpose of whitespace warnings

### DIFF
--- a/docsrc/warnings.rst
+++ b/docsrc/warnings.rst
@@ -208,6 +208,24 @@ Whitespace issues
 
 Luacheck warns about trailing whitespace and inconsistent indentation (``SPACE`` followed by ``TAB``).
 
+Some examples of trailing white space Luacheck will find
+
+.. code-block:: lua
+   :linenos:
+   
+   -- white space example
+   print("Hello")
+
+   print("World")
+
+Here
+
+* Any tabs or spaces after the end of either ``)`` would be cosidered trailing
+* Any tabs or spaces after the ``e`` in the comment would be considered trailing
+* The empty line between the two ``print`` statements would also be considered a form of trailing whitespace
+
+Trailing whitespace in any of these forms can be a nuisance to developers navigating around a file and is forbidden in many formatting styles.
+
 Line length limits
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Added clarifications on the purpose of whitespace warnings that Luacheck generates to its documentation.