### PR TITLE
631 ("line is too long"): set column according to start

### DIFF
--- a/spec/cli_spec.lua
+++ b/spec/cli_spec.lua
@@ -552,14 +552,14 @@ Total: 6 warnings / 0 errors in 1 file
       assert.equal([[
 Checking spec/samples/line_length.lua             8 warnings
 
-    spec/samples/line_length.lua:2:1: line is too long (123 > 120)
-    spec/samples/line_length.lua:3:1: line is too long (164 > 120)
-    spec/samples/line_length.lua:8:1: line is too long (134 > 120)
-    spec/samples/line_length.lua:13:1: line is too long (47 > 40)
-    spec/samples/line_length.lua:18:1: line is too long (132 > 120)
-    spec/samples/line_length.lua:22:1: line is too long (85 > 80)
-    spec/samples/line_length.lua:26:1: line is too long (104 > 100)
-    spec/samples/line_length.lua:29:1: line is too long (125 > 120)
+    spec/samples/line_length.lua:2:121: line is too long (123 > 120)
+    spec/samples/line_length.lua:3:121: line is too long (164 > 120)
+    spec/samples/line_length.lua:8:121: line is too long (134 > 120)
+    spec/samples/line_length.lua:13:41: line is too long (47 > 40)
+    spec/samples/line_length.lua:18:121: line is too long (132 > 120)
+    spec/samples/line_length.lua:22:81: line is too long (85 > 80)
+    spec/samples/line_length.lua:26:101: line is too long (104 > 100)
+    spec/samples/line_length.lua:29:121: line is too long (125 > 120)
 
 Total: 8 warnings / 0 errors in 1 file
 ]], get_output "spec/samples/line_length.lua --no-config")
@@ -567,13 +567,13 @@ Total: 8 warnings / 0 errors in 1 file
       assert.equal([[
 Checking spec/samples/line_length.lua             7 warnings
 
-    spec/samples/line_length.lua:3:1: line is too long (164 > 130)
-    spec/samples/line_length.lua:8:1: line is too long (134 > 130)
-    spec/samples/line_length.lua:13:1: line is too long (47 > 40)
-    spec/samples/line_length.lua:18:1: line is too long (132 > 130)
-    spec/samples/line_length.lua:22:1: line is too long (85 > 80)
-    spec/samples/line_length.lua:26:1: line is too long (104 > 100)
-    spec/samples/line_length.lua:29:1: line is too long (125 > 120)
+    spec/samples/line_length.lua:3:131: line is too long (164 > 130)
+    spec/samples/line_length.lua:8:131: line is too long (134 > 130)
+    spec/samples/line_length.lua:13:41: line is too long (47 > 40)
+    spec/samples/line_length.lua:18:131: line is too long (132 > 130)
+    spec/samples/line_length.lua:22:81: line is too long (85 > 80)
+    spec/samples/line_length.lua:26:101: line is too long (104 > 100)
+    spec/samples/line_length.lua:29:121: line is too long (125 > 120)
 
 Total: 7 warnings / 0 errors in 1 file
 ]], get_output "spec/samples/line_length.lua --no-config --max-line-length=130")
@@ -581,10 +581,10 @@ Total: 7 warnings / 0 errors in 1 file
       assert.equal([[
 Checking spec/samples/line_length.lua             4 warnings
 
-    spec/samples/line_length.lua:13:1: line is too long (47 > 40)
-    spec/samples/line_length.lua:22:1: line is too long (85 > 80)
-    spec/samples/line_length.lua:26:1: line is too long (104 > 100)
-    spec/samples/line_length.lua:29:1: line is too long (125 > 120)
+    spec/samples/line_length.lua:13:41: line is too long (47 > 40)
+    spec/samples/line_length.lua:22:81: line is too long (85 > 80)
+    spec/samples/line_length.lua:26:101: line is too long (104 > 100)
+    spec/samples/line_length.lua:29:121: line is too long (125 > 120)
 
 Total: 4 warnings / 0 errors in 1 file
 ]], get_output "spec/samples/line_length.lua --no-config --no-max-line-length")
@@ -592,13 +592,13 @@ Total: 4 warnings / 0 errors in 1 file
       assert.equal([[
 Checking spec/samples/line_length.lua             7 warnings
 
-    spec/samples/line_length.lua:2:1: line is too long (123 > 120)
-    spec/samples/line_length.lua:3:1: line is too long (164 > 120)
-    spec/samples/line_length.lua:13:1: line is too long (47 > 40)
-    spec/samples/line_length.lua:18:1: line is too long (132 > 120)
-    spec/samples/line_length.lua:22:1: line is too long (85 > 80)
-    spec/samples/line_length.lua:26:1: line is too long (104 > 100)
-    spec/samples/line_length.lua:29:1: line is too long (125 > 120)
+    spec/samples/line_length.lua:2:121: line is too long (123 > 120)
+    spec/samples/line_length.lua:3:121: line is too long (164 > 120)
+    spec/samples/line_length.lua:13:41: line is too long (47 > 40)
+    spec/samples/line_length.lua:18:121: line is too long (132 > 120)
+    spec/samples/line_length.lua:22:81: line is too long (85 > 80)
+    spec/samples/line_length.lua:26:101: line is too long (104 > 100)
+    spec/samples/line_length.lua:29:121: line is too long (125 > 120)
 
 Total: 7 warnings / 0 errors in 1 file
 ]], get_output "spec/samples/line_length.lua --no-config --no-max-string-line-length")

--- a/spec/filter_spec.lua
+++ b/spec/filter_spec.lua
@@ -637,8 +637,8 @@ describe("filter", function()
    it("adds line length warnings", function()
       assert.same({
          {
-            {code = "631", line = 2, column = 1, end_column = 121, max_length = 120},
-            {code = "631", line = 5, column = 1, end_column = 18, line_ending = "string", max_length = 15}
+            {code = "631", line = 2, column = 121, end_column = 121, max_length = 120},
+            {code = "631", line = 5, column = 16, end_column = 18, line_ending = "string", max_length = 15}
          }
       }, filter_full({
          {

--- a/src/luacheck/filter.lua
+++ b/src/luacheck/filter.lua
@@ -318,6 +318,7 @@ local function filter_file_report(report)
          if not filters(opts, issue) then
             if issue.code == "631" then
                issue.max_length = get_max_line_length(opts, issue)
+               issue.column = issue.max_length + 1
             end
 
             if issue.code:match("1[24][23]") then
@@ -423,7 +424,8 @@ local function add_long_line_warnings(report)
          }
 
          for line_number, length in ipairs(file_report.line_lengths) do
-            -- `max_length` field will be added later.
+            -- `max_length` field will be added later,
+            -- `column` will be updated later.
             table.insert(res[i].events, {
                code = "631",
                line = line_number,


### PR DESCRIPTION
This changes the `column` for "line is too long" warnings to the start
of the too long text.