### PR TITLE
Added the missing ngx.ERROR constant

### DIFF
--- a/src/luacheck/ngx_standard.lua
+++ b/src/luacheck/ngx_standard.lua
@@ -14,6 +14,7 @@ local ngx_defs = {
             arg = {other_fields = true, read_only = false},
             var = {other_fields = true, read_only = false},
             OK = empty,
+            ERROR = empty,
             AGAIN = empty,
             DONE = empty,
             DECLINED = empty,


### PR DESCRIPTION
I somehow missed that constant on my initial pull request (documented there: https://github.com/openresty/lua-nginx-module#core-constants).

A possible workaround for people affected by the bug is to add this in the `.luacheckrc` file

```lua
stds.ngx_patched = {         
   globals = {
      ngx = {
         fields = {
            ERROR = {},
         },
      },
   },
}
std = "ngx_lua+ngx_patched"
```