### PR TITLE
fix typo

### DIFF
--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -41,7 +41,7 @@ The output of ``luacheck`` consists of separate reports for each checked file an
 ``luacheck`` chooses exit code as follows:
 
 * Exit code is ``0`` if no warnings or errors occurred.
-* Exit code is ``1`` if some warnings occured but there were no syntax errors or invalid inline options.
+* Exit code is ``1`` if some warnings occurred but there were no syntax errors or invalid inline options.
 * Exit code is ``2`` if there were some syntax errors or invalid inline options.
 * Exit code is ``3`` if some files couldn't be checked, typically due to an incorrect file name.
 * Exit code is ``4`` if there was a critical error (invalid CLI arguments, config, or cache file).


### PR DESCRIPTION
thanks to lintian
> lua-check: spelling-error-in-manpage usr/share/man/man1/luacheck.1.gz occured occurred