### PR TITLE
Sprinkle $(realpath ...) invocations for symlink-ability

### DIFF
--- a/install.lua
+++ b/install.lua
@@ -76,7 +76,7 @@ else
    fh:write(([=[
 #!/bin/sh
 exec "%s" -e "package.path=[[%s/../src/?.lua;%s/../src/?/init.lua;]]..package.path" "%s/luacheck.lua" "$@"
-]=]):format(args.lua, '$(dirname "$0")', '$(dirname "$0")', '$(dirname "$0")'))
+]=]):format(args.lua, '$(dirname $(realpath "$0"))', '$(dirname $(realpath "$0"))', '$(dirname $(realpath "$0"))'))
 end
 
 fh:close()

--- a/install.lua
+++ b/install.lua
@@ -17,6 +17,7 @@ Luacheck modules will be installed into <path>%ssrc.
 Pass . to build luacheck executable script without installing.]]):format(dirsep, dirsep))
 
 parser:option("--lua", "Absolute path to lua interpreter or its name if it's in PATH.", lua_executable)
+parser:option("--destdir", "Path to stage luacheck installation into")
 
 local args = parser:parse()
 
@@ -33,6 +34,9 @@ local function run_command(cmd)
 end
 
 local function mkdir(dir)
+   if args.destdir then
+      dir = args.destdir .. dirsep .. dir
+   end
    if is_windows then
       run_command(([[if not exist "%s" md "%s"]]):format(dir, dir))
    else
@@ -41,6 +45,9 @@ local function mkdir(dir)
 end
 
 local function copy(src, dest)
+   if args.destdir then
+      dest = args.destdir .. dirsep .. dest
+   end
    if is_windows then
       run_command(([[copy /y "%s" "%s"]]):format(src, dest))
    else

--- a/install.lua
+++ b/install.lua
@@ -82,8 +82,8 @@ if is_windows then
 else
    fh:write(([=[
 #!/bin/sh
-exec "%s" -e "package.path=[[%s/../src/?.lua;%s/../src/?/init.lua;]]..package.path" "%s/luacheck.lua" "$@"
-]=]):format(args.lua, '$(dirname $(realpath "$0"))', '$(dirname $(realpath "$0"))', '$(dirname $(realpath "$0"))'))
+exec "%s" -e "package.path=[[%s/?.lua;%s/?/init.lua;]]..package.path" "%s/luacheck.lua" "$@"
+]=]):format(args.lua, luacheck_src_dir, luacheck_src_dir, '$(dirname "$0")'))
 end
 
 fh:close()


### PR DESCRIPTION
At the moment, trying to install luacheck into /usr/local/lua/5.2/luacheck and
then symlinking /usr/local/lua/5.2/luacheck/bin/luacheck into /usr/local/bin results
in a failure as luacheck tries to locate its sources with respect to where the
symlink lives.

Add some $(realpath ...) to get the real location of luacheck for discovery of
its sources.