### PR TITLE
Force lower-case during path normalization.

### DIFF
--- a/src/luacheck/fs.lua
+++ b/src/luacheck/fs.lua
@@ -46,6 +46,7 @@ function fs.is_absolute(path)
 end
 
 function fs.normalize(path)
+   path = path:lower()
    local base, rest = fs.split_base(path)
    rest = rest:gsub("[/\\]", utils.dir_sep)
 

--- a/src/luacheck/fs.lua
+++ b/src/luacheck/fs.lua
@@ -46,7 +46,9 @@ function fs.is_absolute(path)
 end
 
 function fs.normalize(path)
-   path = path:lower()
+   if utils.is_windows then
+      path = path:lower()
+   end
    local base, rest = fs.split_base(path)
    rest = rest:gsub("[/\\]", utils.dir_sep)
 


### PR DESCRIPTION
File paths are never case-sensitive. This fixes an issue that leads to false negatives when matching globs. 