### PR TITLE
Add busted's `match` global to `builtin_standards`

### DIFF
--- a/src/luacheck/builtin_standards/init.lua
+++ b/src/luacheck/builtin_standards/init.lua
@@ -271,7 +271,7 @@ builtin_standards._G = builtin_standards[get_running_lua_std_name()]
 
 builtin_standards.busted = {
    read_globals = {
-      "describe", "insulate", "expose", "it", "pending", "before_each", "after_each",
+      "describe", "insulate", "expose", "it", "pending", "before_each", "after_each", "match",
       "lazy_setup", "lazy_teardown", "strict_setup", "strict_teardown", "setup", "teardown",
       "context", "spec", "test", "assert", "spy", "mock", "stub", "finally", "randomize"
    }


### PR DESCRIPTION
The busted project has the concept of matchers than are documented over at
https://olivinelabs.com/busted/#matchers and can be used in assertions with
the `match` keyword.

For example:

```lua
assert.spy(s).was_called_with(match.is_string())
```