### PR TITLE
Add Nova extension information to "Editor support" section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ There are a few plugins which allow using Luacheck directly inside an editor, sh
 * For Atom there is [linter-luacheck](https://atom.io/packages/linter-luacheck) which requires [AtomLinter](https://github.com/steelbrain/linter);
 * For Emacs, [Flycheck](http://www.flycheck.org/en/latest/) contains [luacheck checker](http://www.flycheck.org/en/latest/languages.html#lua);
 * For Brackets, there is [linter.luacheck](https://github.com/Malcolm3141/brackets-luacheck) extension;
-* For Visual Studio code there is [vscode-luacheck](https://marketplace.visualstudio.com/items?itemName=dwenegar.vscode-luacheck) extension. [vscode-lua](https://marketplace.visualstudio.com/items?itemName=trixnz.vscode-lua) extension also includes Luacheck support.
+* For Visual Studio code there is [vscode-luacheck](https://marketplace.visualstudio.com/items?itemName=dwenegar.vscode-luacheck) extension. [vscode-lua](https://marketplace.visualstudio.com/items?itemName=trixnz.vscode-lua) extension also includes Luacheck support;
+* For Nova, search the Extension Library for the [Luacheck](https://github.com/GarrettAlbright/Luacheck.novaextension) extension.
 
 If you are a plugin developer, see [recommended way of using Luacheck in a plugin](http://luacheck.readthedocs.org/en/stable/cli.html#stable-interface-for-editor-plugins-and-tools).
 


### PR DESCRIPTION
I created an extension for the [Nova](https://nova.app/) editor which integrates Luacheck. This PR just adds information about it to the README.